### PR TITLE
[Fix] 차트 배치 및 크기 변경

### DIFF
--- a/statify-ulber/src/App.css
+++ b/statify-ulber/src/App.css
@@ -193,7 +193,16 @@
 /* Charts Grid */
 .charts-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+  /*grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));*/
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.overview-charts-grid {
+  display: grid;
+  /*grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));*/
+  grid-template-columns: repeat(4, 1fr);
   gap: 20px;
   margin-bottom: 20px;
 }

--- a/statify-ulber/src/App.jsx
+++ b/statify-ulber/src/App.jsx
@@ -247,7 +247,7 @@ function App() {
       {activeTab === 'overview' && (
         <>
           {filteredData.length === 0 ? 0 : (
-            <div className="charts-grid">
+            <div className="overview-charts-grid">
               <BookingStatusChart data={chartData.bookingStatus} />
               <VehicleTypeChart data={chartData.vehicleType} />
               <PaymentMethodChart data={chartData.paymentMethod} />

--- a/statify-ulber/src/components/Charts.jsx
+++ b/statify-ulber/src/components/Charts.jsx
@@ -22,7 +22,7 @@ export const BookingStatusChart = React.memo(({ data }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">Booking Status Distribution</h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={500}>
         <PieChart>
           <Pie
             data={data}
@@ -49,7 +49,7 @@ export const VehicleTypeChart = React.memo(({ data }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">Bookings by Vehicle Type</h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={500}>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" angle={-45} textAnchor="end" height={80} />
@@ -67,7 +67,7 @@ export const PaymentMethodChart = React.memo(({ data }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">Payment Methods Distribution</h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={500}>
         <PieChart>
           <Pie
             data={data}
@@ -94,7 +94,7 @@ export const BookingsByHourChart = React.memo(({ data }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">Bookings by Hour of Day</h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={500}>
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="hour" />
@@ -112,7 +112,7 @@ export const TopLocationsChart = React.memo(({ data, title }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">{title}</h3>
-      <ResponsiveContainer width="100%" height={1000}>
+      <ResponsiveContainer width="100%" height={500}>
         <BarChart data={data} layout="vertical">
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" />
@@ -130,7 +130,7 @@ export const RevenueByVehicleChart = React.memo(({ data }) => {
   return (
     <div className="chart-container">
       <h3 className="chart-title">Revenue by Vehicle Type (USD)</h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={500}>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" angle={-45} textAnchor="end" height={80} />


### PR DESCRIPTION
## 🔥 관련 이슈

이 PR과 관련된 Issue 번호를 연결해 주세요 (#34 )

<br><br>

## 📃 변경 사항

어떤 부분이 추가 / 변경되었는지 요약해주세요

- overview 하단에 표시되는 차트 4개가 한 줄에 전부 표시
- charts에 표시되는 차트 6개를 한 줄에 3개씩 나타나도록 변경
- 전체 차트크기 변경

<br><br>

## 🛠 구현 상세

### 1. 구체적인 구현 방법
Top10 drop locations와 Top10 pickup locations의 높이변경이 다른 차트에도 영향을 줌

10개 항목 전체를 보여줄 수 있는 높이 최솟값을 찾은 뒤, 다른 모든 차트에 동일하게 적용

<ResponsiveContainer width="100%" height={500}>

수정 전
<img width="1917" height="919" alt="차트크기불균형" src="https://github.com/user-attachments/assets/4b3f463b-d59f-425e-b6b0-1b77e494a362" />


수정 후
<img width="1918" height="920" alt="크기일치" src="https://github.com/user-attachments/assets/162cf1c1-2a58-4427-9b0e-555099662f0c" />

<br>

### 2. 구체적인 구현 방법

<img width="522" height="315" alt="image" src="https://github.com/user-attachments/assets/fd901723-5e0c-48a6-8f26-02228680f101" />

기존 charts-grid 클래스를 .charts-grid, .overview-chart-grid로 분할

 .overview-charts-grid는 한 줄에 차트 4개가 전부 표시되도록 설정
<img width="1917" height="920" alt="4X1" src="https://github.com/user-attachments/assets/6b3d102d-d749-4ab9-b7b2-2cd8d9fc2490" />

.charts-grid는 한 줄에 차트 3개씩 표시되도록 설정
<img width="1169" height="833" alt="3x2" src="https://github.com/user-attachments/assets/ca46f25a-8570-42cf-808f-cc7b124be58e" />

