### PR TITLE
[Fix] 한글/영어 토글 가능하도록 수정

### DIFF
--- a/statify-ulber/src/App.css
+++ b/statify-ulber/src/App.css
@@ -38,6 +38,35 @@
   font-weight: 400;
 }
 
+.header-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.lang-toggle-btn {
+  padding: 10px 16px;
+  background: white;
+  color: #667eea;
+  border: 2px solid #667eea;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.lang-toggle-btn:hover {
+  background: #667eea;
+  color: white;
+  transform: scale(1.05);
+}
+
+.lang-toggle-btn:active {
+  transform: scale(0.98);
+}
+
 .refresh-btn {
   padding: 10px 20px;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/statify-ulber/src/App.jsx
+++ b/statify-ulber/src/App.jsx
@@ -13,6 +13,7 @@ import {
   getBookingsByDate
 } from './utils/statsUtils';
 import { exportStatsToCSV } from './utils/exportUtils';
+import { translations } from './utils/translations';
 
 import StatsCard from './components/StatsCard';
 import FilterPanel from './components/FilterPanel';
@@ -32,6 +33,9 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
+  const [lang, setLang] = useState('ko');
+
+  const t = translations[lang];
 
   const loadData = async () => {
     try {
@@ -90,8 +94,8 @@ function App() {
       <div className="app-container">
         <div className="loading">
           <div className="spinner"></div>
-          <p>예약 데이터 로딩 중...</p>
-          <p className="loading-subtitle">대용량 데이터의 경우 시간이 소요될 수 있습니다</p>
+          <p>{t.loadingData}</p>
+          <p className="loading-subtitle">{t.loadingSubtitle}</p>
         </div>
       </div>
     );
@@ -101,10 +105,10 @@ function App() {
     return (
       <div className="app-container">
         <div className="error">
-          <h2>데이터 로딩 오류</h2>
+          <h2>{t.loadError}</h2>
           <p>{error}</p>
           <button onClick={loadData} className="retry-btn">
-            다시 시도
+            {t.retry}
           </button>
         </div>
       </div>
@@ -115,10 +119,10 @@ function App() {
   const NoDataMessage = () => {
     return (
       <div className='no-data-meeage' style={{ padding: '40px', textAlign: 'center', backgroundColor: '#f9fafb', borderRadius: '12px', marginTop: '20px', border: '1px solid #e5e7eb' }} >
-        <h3 style={{ color: '#ef4444', marginBottom: '10px' }}>데이터 없음</h3>
-        <p style={{ color: '#4b5563' }}> 해당되는 데이터가 존재하지 않습니다. 필터를 조정하거나 초기화해 보세요.</p>
+        <h3 style={{ color: '#ef4444', marginBottom: '10px' }}>{t.noData}</h3>
+        <p style={{ color: '#4b5563' }}>{t.noDataMessage}</p>
         <button onClick={handleResetFilters} style={{ marginTop: '20px', padding: '10px 20px', backgroundColor: '#3b82f6', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer', fontSize: '16px' }}>
-          필터 초기화
+          {t.resetFilters}
         </button>
       </div>
     )
@@ -129,15 +133,24 @@ function App() {
       <header className="app-header">
         <div className="header-content">
           <div>
-            <h1>예약 분석 대시보드</h1>
-            <h3>팀: Statify</h3>
+            <h1>{t.dashboardTitle}</h1>
+            <h3>{t.teamName}</h3>
             <p className="subtitle">
-              {rawData.length.toLocaleString()}개의 예약 기록 종합 분석
+              {rawData.length.toLocaleString()}{t.recordsAnalysis}
             </p>
           </div>
-          <button onClick={loadData} className="refresh-btn" title="데이터 새로고침">
-            ↻ 새로고침
-          </button>
+          <div className="header-actions">
+            <button
+              onClick={() => setLang(lang === 'ko' ? 'en' : 'ko')}
+              className="lang-toggle-btn"
+              title={lang === 'ko' ? 'Switch to English' : '한국어로 변경'}
+            >
+              {lang === 'ko' ? '한' : 'EN'}
+            </button>
+            <button onClick={loadData} className="refresh-btn" title={t.refresh}>
+              ↻ {t.refresh}
+            </button>
+          </div>
         </div>
       </header>
 
@@ -146,19 +159,19 @@ function App() {
           className={`tab ${activeTab === 'overview' ? 'active' : ''}`}
           onClick={() => setActiveTab('overview')}
         >
-          개요
+          {t.overview}
         </button>
         <button
           className={`tab ${activeTab === 'charts' ? 'active' : ''}`}
           onClick={() => setActiveTab('charts')}
         >
-          차트
+          {t.charts}
         </button>
         <button
           className={`tab ${activeTab === 'data' ? 'active' : ''}`}
           onClick={() => setActiveTab('data')}
         >
-          데이터 테이블
+          {t.dataTable}
         </button>
       </div>
 
@@ -169,64 +182,65 @@ function App() {
             onFiltersChange={setFilters}
             availableOptions={availableOptions}
             onReset={handleResetFilters}
+            t={t}
           />
 
           {filteredData.length === 0 ? NoDataMessage() : (
             <div className='stats-grid'>
               <StatsCard
-                title="총 예약"
+                title={t.totalBookings}
                 value={stats.totalBookings.toLocaleString()}
-                subtitle={`${stats.completedBookings.toLocaleString()}건 완료됨`}
+                subtitle={`${stats.completedBookings.toLocaleString()}${t.completed}`}
                 color="#3b82f6"
               />
 
               <StatsCard
-                title="완료율"
+                title={t.completionRate}
                 value={`${stats.completionRate}%`}
-                subtitle="성공적으로 완료된 운행"
+                subtitle={t.successfulRides}
                 color="#10b981"
               />
 
               <StatsCard
-                title="취소율"
+                title={t.cancellationRate}
                 value={`${stats.cancellationRate}%`}
-                subtitle={`${stats.totalCancelled.toLocaleString()}건 총 취소`}
+                subtitle={`${stats.totalCancelled.toLocaleString()}${t.totalCancelled}`}
                 color="#ef4444"
               />
               <StatsCard
-                title="총 수익"
+                title={t.totalRevenue}
                 value={`$${parseFloat(stats.totalRevenue).toLocaleString()}`}
-                subtitle={`평균: $${stats.avgRevenue} 운행당`}
+                subtitle={`${lang === 'ko' ? '평균' : 'Avg'}: $${stats.avgRevenue} ${t.avgPerRide}`}
                 color="#f59e0b"
               />
               <StatsCard
-                title="평균 운전자 평점"
+                title={t.avgDriverRating}
                 value={stats.avgDriverRating}
-                subtitle="5.0점 만점"
+                subtitle={t.outOf5}
                 color="#8b5cf6"
               />
               <StatsCard
-                title="평균 고객 평점"
+                title={t.avgCustomerRating}
                 value={stats.avgCustomerRating}
-                subtitle="5.0점 만점"
+                subtitle={t.outOf5}
                 color="#ec4899"
               />
               <StatsCard
-                title="총 거리"
+                title={t.totalDistance}
                 value={`${parseFloat(stats.totalDistance).toLocaleString()} km`}
-                subtitle={`평균: ${stats.avgDistance} km 운행당`}
+                subtitle={`${lang === 'ko' ? '평균' : 'Avg'}: ${stats.avgDistance} km ${t.perRide}`}
                 color="#14b8a6"
               />
               <StatsCard
-                title="고객 취소"
+                title={t.customerCancelled}
                 value={stats.cancelledByCustomer.toLocaleString()}
-                subtitle="고객 취소 건수"
+                subtitle={t.customerCancelledCount}
                 color="#f97316"
               />
               <StatsCard
-                title="운전자 취소"
+                title={t.driverCancelled}
                 value={stats.cancelledByDriver.toLocaleString()}
-                subtitle="운전자 취소 건수"
+                subtitle={t.driverCancelledCount}
                 color="#ef4444"
               />
             </div>
@@ -237,7 +251,7 @@ function App() {
               onClick={() => exportStatsToCSV(stats)}
               className="export-stats-btn"
             >
-              통계 내보내기
+              {t.exportStats}
             </button>
           </div>
         </>
@@ -247,10 +261,10 @@ function App() {
         <>
           {filteredData.length === 0 ? 0 : (
             <div className="overview-charts-grid">
-              <BookingStatusChart data={chartData.bookingStatus} />
-              <VehicleTypeChart data={chartData.vehicleType} />
-              <PaymentMethodChart data={chartData.paymentMethod} />
-              <RevenueByVehicleChart data={chartData.revenueByVehicle} />
+              <BookingStatusChart data={chartData.bookingStatus} t={t} />
+              <VehicleTypeChart data={chartData.vehicleType} t={t} />
+              <PaymentMethodChart data={chartData.paymentMethod} t={t} />
+              <RevenueByVehicleChart data={chartData.revenueByVehicle} t={t} />
             </div>
           )}
         </>
@@ -261,18 +275,18 @@ function App() {
           {filteredData.length === 0 ? NoDataMessage() : (
             <div className="charts-layout">
               <div className="charts-grid">
-                <BookingStatusChart data={chartData.bookingStatus} />
-                <VehicleTypeChart data={chartData.vehicleType} />
-                <PaymentMethodChart data={chartData.paymentMethod} />
-                <BookingsByHourChart data={chartData.bookingsByHour} />
+                <BookingStatusChart data={chartData.bookingStatus} t={t} />
+                <VehicleTypeChart data={chartData.vehicleType} t={t} />
+                <PaymentMethodChart data={chartData.paymentMethod} t={t} />
+                <BookingsByHourChart data={chartData.bookingsByHour} t={t} />
                 <TopLocationsChart
                   data={chartData.topDropLocations}
-                  title="상위 10개 도착 위치"
+                  title={t.topDropLocations}
                 />
 
                 <TopLocationsChart
                   data={chartData.topPickupLocations}
-                  title="상위 10개 픽업 위치"
+                  title={t.topPickupLocations}
                 />
 
               </div>
@@ -281,13 +295,13 @@ function App() {
         </>
       )}
 
-      {activeTab === 'data' && <DataTable data={filteredData} />}
+      {activeTab === 'data' && <DataTable data={filteredData} t={t} />}
 
       <footer className="app-footer">
         <p>
-          {rawData.length.toLocaleString()}개 중 {filteredData.length.toLocaleString()}개의 예약 표시
+          {rawData.length.toLocaleString()}{t.showingOf} {filteredData.length.toLocaleString()}{t.bookingsDisplayed}
         </p>
-        <p>Statify 예약 분석 대시보드 © 2025</p>
+        <p>{t.copyright}</p>
       </footer>
     </div>
   );

--- a/statify-ulber/src/components/Charts.jsx
+++ b/statify-ulber/src/components/Charts.jsx
@@ -18,10 +18,10 @@ import './Charts.css';
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6', '#f97316'];
 
-export const BookingStatusChart = React.memo(({ data }) => {
+export const BookingStatusChart = React.memo(({ data, t }) => {
   return (
     <div className="chart-container">
-<h3 className="chart-title">예약 상태 분포</h3>
+<h3 className="chart-title">{t?.bookingStatusDist || '예약 상태 분포'}</h3>
       <ResponsiveContainer width="100%" height={500}>
         <PieChart>
           <Pie
@@ -45,10 +45,10 @@ export const BookingStatusChart = React.memo(({ data }) => {
   );
 });
 
-export const VehicleTypeChart = React.memo(({ data }) => {
+export const VehicleTypeChart = React.memo(({ data, t }) => {
   return (
     <div className="chart-container">
-<h3 className="chart-title">차량 유형별 예약</h3>
+<h3 className="chart-title">{t?.bookingsByVehicle || '차량 유형별 예약'}</h3>
       <ResponsiveContainer width="100%" height={500}>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
@@ -63,10 +63,10 @@ export const VehicleTypeChart = React.memo(({ data }) => {
   );
 });
 
-export const PaymentMethodChart = React.memo(({ data }) => {
+export const PaymentMethodChart = React.memo(({ data, t }) => {
   return (
     <div className="chart-container">
- <h3 className="chart-title">결제 수단 분포</h3>
+ <h3 className="chart-title">{t?.paymentMethodDist || '결제 수단 분포'}</h3>
       <ResponsiveContainer width="100%" height={500}>
         <PieChart>
           <Pie
@@ -90,10 +90,10 @@ export const PaymentMethodChart = React.memo(({ data }) => {
   );
 });
 
-export const BookingsByHourChart = React.memo(({ data }) => {
+export const BookingsByHourChart = React.memo(({ data, t }) => {
   return (
     <div className="chart-container">
-      <h3 className="chart-title">시간대별 예약</h3>
+      <h3 className="chart-title">{t?.bookingsByHour || '시간대별 예약'}</h3>
       <ResponsiveContainer width="100%" height={500}>
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
@@ -126,10 +126,10 @@ export const TopLocationsChart = React.memo(({ data, title }) => {
   );
 });
 
-export const RevenueByVehicleChart = React.memo(({ data }) => {
+export const RevenueByVehicleChart = React.memo(({ data, t }) => {
   return (
     <div className="chart-container">
-<h3 className="chart-title">차량 유형별 수익 (USD)</h3>
+<h3 className="chart-title">{t?.revenueByVehicle || '차량 유형별 수익 (USD)'}</h3>
       <ResponsiveContainer width="100%" height={500}>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
@@ -144,13 +144,13 @@ export const RevenueByVehicleChart = React.memo(({ data }) => {
   );
 });
 
-export const BookingsTrendChart = React.memo(({ data }) => {
+export const BookingsTrendChart = React.memo(({ data, t }) => {
   // Take only first 30 dates for better visualization
   const limitedData = data.slice(0, 30);
 
   return (
     <div className="chart-container wide">
-      <h3 className="chart-title">예약 추이 (최근 30일)</h3>
+      <h3 className="chart-title">{t?.bookingsTrend || '예약 추이 (최근 30일)'}</h3>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={limitedData}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/statify-ulber/src/components/DataTable.jsx
+++ b/statify-ulber/src/components/DataTable.jsx
@@ -3,7 +3,7 @@ import { sortData } from '../utils/filterUtils';
 import { exportToCSV, exportToJSON } from '../utils/exportUtils';
 import './DataTable.css';
 
-const DataTable = ({ data }) => {
+const DataTable = ({ data, t }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(50);
   const [sortBy, setSortBy] = useState('Date');
@@ -47,24 +47,24 @@ const DataTable = ({ data }) => {
   };
 
   const columns = [
-    { key: 'Date', label: 'Date' },
-    { key: 'Time', label: 'Time' },
-    { key: 'Booking ID', label: 'Booking ID' },
-    { key: 'Booking Status', label: 'Status' },
-    { key: 'Vehicle Type', label: 'Vehicle' },
-    { key: 'Pickup Location', label: 'Pickup' },
-    { key: 'Drop Location', label: 'Drop' },
-    { key: 'bookingValueUSD', label: 'Price (USD)' },
-    { key: 'rideDistance', label: 'Distance (km)' },
-    { key: 'driverRating', label: 'Driver Rating' },
-    { key: 'customerRating', label: 'Customer Rating' },
-    { key: 'Payment Method', label: 'Payment' }
+    { key: 'Date', label: t?.date || 'Date' },
+    { key: 'Time', label: t?.time || 'Time' },
+    { key: 'Booking ID', label: t?.bookingId || 'Booking ID' },
+    { key: 'Booking Status', label: t?.status || 'Status' },
+    { key: 'Vehicle Type', label: t?.vehicle || 'Vehicle' },
+    { key: 'Pickup Location', label: t?.pickup || 'Pickup' },
+    { key: 'Drop Location', label: t?.drop || 'Drop' },
+    { key: 'bookingValueUSD', label: t?.priceUSD || 'Price (USD)' },
+    { key: 'rideDistance', label: t?.distanceKm || 'Distance (km)' },
+    { key: 'driverRating', label: t?.driverRating || 'Driver Rating' },
+    { key: 'customerRating', label: t?.customerRating || 'Customer Rating' },
+    { key: 'Payment Method', label: t?.payment || 'Payment' }
   ];
 
   return (
     <div className="data-table-container">
       <div className="table-header">
-        <h3>Booking Data ({sortedData.length} records)</h3>
+        <h3>{t?.bookingData || 'Booking Data'} ({sortedData.length}{t?.records || ' records'})</h3>
         <div className="table-actions">
           <select
             value={itemsPerPage}
@@ -74,22 +74,22 @@ const DataTable = ({ data }) => {
             }}
             className="items-per-page-select"
           >
-            <option value={25}>25 per page</option>
-            <option value={50}>50 per page</option>
-            <option value={100}>100 per page</option>
-            <option value={200}>200 per page</option>
+            <option value={25}>25{t?.perPage || ' per page'}</option>
+            <option value={50}>50{t?.perPage || ' per page'}</option>
+            <option value={100}>100{t?.perPage || ' per page'}</option>
+            <option value={200}>200{t?.perPage || ' per page'}</option>
           </select>
           <button
             onClick={() => exportToCSV(sortedData)}
             className="export-btn"
           >
-            Export CSV
+            {t?.exportCSV || 'Export CSV'}
           </button>
           <button
             onClick={() => exportToJSON(sortedData)}
             className="export-btn"
           >
-            Export JSON
+            {t?.exportJSON || 'Export JSON'}
           </button>
         </div>
       </div>
@@ -143,7 +143,7 @@ const DataTable = ({ data }) => {
 
       <div className="table-footer">
         <div className="pagination-info">
-          Showing {startIndex + 1} to {Math.min(endIndex, sortedData.length)} of {sortedData.length} entries
+          {t?.showing || 'Showing'} {startIndex + 1} {t?.to || 'to'} {Math.min(endIndex, sortedData.length)} {t?.of || 'of'} {sortedData.length} {t?.entries || 'entries'}
         </div>
         <div className="pagination">
           <button

--- a/statify-ulber/src/components/FilterPanel.jsx
+++ b/statify-ulber/src/components/FilterPanel.jsx
@@ -5,7 +5,8 @@ const FilterPanel = React.memo(({
   filters,
   onFiltersChange,
   availableOptions,
-  onReset
+  onReset,
+  t
 }) => {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -132,14 +133,14 @@ const FilterPanel = React.memo(({
     <div className="filter-panel">
       <div className="filter-header">
         <h3>
-          필터
+          {t?.filters || '필터'}
           {activeFilterCount > 0 && (
             <span className="filter-badge">{activeFilterCount}</span>
           )}
         </h3>
         <div className="filter-actions">
           <button onClick={onReset} className="btn-reset">
-            전체 초기화
+            {t?.resetAll || '전체 초기화'}
           </button>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
@@ -154,11 +155,11 @@ const FilterPanel = React.memo(({
         <div className="filter-content">
           {/* Search */}
           <div className="filter-section">
-            <label className="filter-label">검색</label>
+            <label className="filter-label">{t?.search || '검색'}</label>
             <input
               type="text"
               className="filter-input"
-              placeholder="ID, 위치, 차량으로 검색..."
+              placeholder={t?.searchPlaceholder || 'ID, 위치, 차량으로 검색...'}
               value={filters.searchText || ''}
               onChange={(e) => handleInputChange('searchText', e.target.value)}
             />
@@ -166,25 +167,25 @@ const FilterPanel = React.memo(({
 
           {/* Date Range */}
           <div className="filter-section">
-            <label className="filter-label">날짜 범위</label>
+            <label className="filter-label">{t?.dateRange || '날짜 범위'}</label>
             <div className="date-presets">
               <button
                 onClick={() => setDatePreset('last7')}
                 className="preset-btn"
               >
-                최근 7일
+                {t?.last7Days || '최근 7일'}
               </button>
               <button
                 onClick={() => setDatePreset('last30')}
                 className="preset-btn"
               >
-                최근 30일
+                {t?.last30Days || '최근 30일'}
               </button>
               <button
                 onClick={() => setDatePreset('all')}
                 className="preset-btn"
               >
-                전체 기간
+                {t?.allPeriod || '전체 기간'}
               </button>
             </div>
             <div className="date-range">
@@ -210,7 +211,7 @@ const FilterPanel = React.memo(({
 
           {/* Booking Status */}
           <div className="filter-section">
-            <label className="filter-label">예약 상태</label>
+            <label className="filter-label">{t?.bookingStatus || '예약 상태'}</label>
             <div className="checkbox-group">
               {availableOptions.bookingStatuses?.map(status => (
                 <label key={status} className="checkbox-label">
@@ -227,7 +228,7 @@ const FilterPanel = React.memo(({
 
           {/* Vehicle Type */}
           <div className="filter-section">
-            <label className="filter-label">차량 유형</label>
+            <label className="filter-label">{t?.vehicleType || '차량 유형'}</label>
             <div className="checkbox-group">
               {availableOptions.vehicleTypes?.map(type => (
                 <label key={type} className="checkbox-label">
@@ -244,7 +245,7 @@ const FilterPanel = React.memo(({
 
           {/* Payment Method */}
           <div className="filter-section">
-            <label className="filter-label">결제 수단</label>
+            <label className="filter-label">{t?.paymentMethod || '결제 수단'}</label>
             <div className="checkbox-group">
               {availableOptions.paymentMethods?.map(method => (
                 <label key={method} className="checkbox-label">
@@ -261,7 +262,7 @@ const FilterPanel = React.memo(({
 
           {/* Rating Filters */}
           <div className="filter-section">
-            <label className="filter-label">최소 운전자 평점</label>
+            <label className="filter-label">{t?.minDriverRating || '최소 운전자 평점'}</label>
             <input
               type="range"
               min="0"
@@ -275,7 +276,7 @@ const FilterPanel = React.memo(({
           </div>
 
           <div className="filter-section">
-            <label className="filter-label">최소 고객 평점</label>
+            <label className="filter-label">{t?.minCustomerRating || '최소 고객 평점'}</label>
             <input
               type="range"
               min="0"
@@ -290,11 +291,11 @@ const FilterPanel = React.memo(({
 
           {/* Distance Range */}
           <div className="filter-section">
-            <label className="filter-label">거리 범위 (km)</label>
+            <label className="filter-label">{t?.distanceRange || '거리 범위 (km)'}</label>
             <div className="range-inputs">
               <input
                 type="number"
-                placeholder="최소"
+                placeholder={t?.min || '최소'}
                 className="filter-input small"
                 value={filters.minDistance || ''}
                 min={0}
@@ -308,7 +309,7 @@ const FilterPanel = React.memo(({
               <span>-</span>
               <input
                 type="number"
-                placeholder="최대"
+                placeholder={t?.max || '최대'}
                 className="filter-input small"
                 value={filters.maxDistance || ''}
                 min={0}
@@ -323,11 +324,11 @@ const FilterPanel = React.memo(({
 
           {/* Price Range */}
           <div className="filter-section">
-            <label className="filter-label">가격 범위 (USD)</label>
+            <label className="filter-label">{t?.priceRange || '가격 범위 (USD)'}</label>
             <div className="range-inputs">
               <input
                 type="number"
-                placeholder="최소"
+                placeholder={t?.min || '최소'}
                 className="filter-input small"
                 value={filters.minPrice || ''}
                 onChange={(e) =>
@@ -338,7 +339,7 @@ const FilterPanel = React.memo(({
               <span>-</span>
               <input
                 type="number"
-                placeholder="최대"
+                placeholder={t?.max || '최대'}
                 className="filter-input small"
                 value={filters.maxPrice || ''}
                 onChange={(e) => handleInputChange(
@@ -350,7 +351,7 @@ const FilterPanel = React.memo(({
 
           {/* Top Pickup Locations */}
           <div className="filter-section">
-            <label className="filter-label">픽업 위치 (상위 10개)</label>
+            <label className="filter-label">{t?.pickupLocationTop10 || '픽업 위치 (상위 10개)'}</label>
             <div className="checkbox-group scrollable">
               {availableOptions.pickupLocations?.slice(0, 10).map(location => (
                 <label key={location} className="checkbox-label">
@@ -367,7 +368,7 @@ const FilterPanel = React.memo(({
 
           {/* Top Drop Locations */}
           <div className="filter-section">
-            <label className="filter-label">도착 위치 (상위 10개)</label>
+            <label className="filter-label">{t?.dropLocationTop10 || '도착 위치 (상위 10개)'}</label>
             <div className="checkbox-group scrollable">
               {availableOptions.dropLocations?.slice(0, 10).map(location => (
                 <label key={location} className="checkbox-label">

--- a/statify-ulber/src/utils/translations.js
+++ b/statify-ulber/src/utils/translations.js
@@ -1,0 +1,216 @@
+export const translations = {
+  ko: {
+    // Header
+    dashboardTitle: '예약 분석 대시보드',
+    teamName: '팀: Statify',
+    recordsAnalysis: '개의 예약 기록 종합 분석',
+    refresh: '새로고침',
+
+    // Tabs
+    overview: '개요',
+    charts: '차트',
+    dataTable: '데이터 테이블',
+
+    // Loading & Error
+    loadingData: '예약 데이터 로딩 중...',
+    loadingSubtitle: '대용량 데이터의 경우 시간이 소요될 수 있습니다',
+    loadError: '데이터 로딩 오류',
+    retry: '다시 시도',
+
+    // No Data
+    noData: '데이터 없음',
+    noDataMessage: '해당되는 데이터가 존재하지 않습니다. 필터를 조정하거나 초기화해 보세요.',
+    resetFilters: '필터 초기화',
+
+    // Stats Cards
+    totalBookings: '총 예약',
+    completed: '건 완료됨',
+    completionRate: '완료율',
+    successfulRides: '성공적으로 완료된 운행',
+    cancellationRate: '취소율',
+    totalCancelled: '건 총 취소',
+    totalRevenue: '총 수익',
+    avgPerRide: '운행당',
+    avgDriverRating: '평균 운전자 평점',
+    avgCustomerRating: '평균 고객 평점',
+    outOf5: '5.0점 만점',
+    totalDistance: '총 거리',
+    perRide: '운행당',
+    customerCancelled: '고객 취소',
+    customerCancelledCount: '고객 취소 건수',
+    driverCancelled: '운전자 취소',
+    driverCancelledCount: '운전자 취소 건수',
+    exportStats: '통계 내보내기',
+
+    // Charts
+    bookingStatusDist: '예약 상태 분포',
+    bookingsByVehicle: '차량 유형별 예약',
+    paymentMethodDist: '결제 수단 분포',
+    bookingsByHour: '시간대별 예약',
+    topDropLocations: '상위 10개 도착 위치',
+    topPickupLocations: '상위 10개 픽업 위치',
+    revenueByVehicle: '차량 유형별 수익 (USD)',
+    bookingsTrend: '예약 추이 (최근 30일)',
+
+    // Filter Panel
+    filters: '필터',
+    resetAll: '전체 초기화',
+    search: '검색',
+    searchPlaceholder: 'ID, 위치, 차량으로 검색...',
+    dateRange: '날짜 범위',
+    last7Days: '최근 7일',
+    last30Days: '최근 30일',
+    allPeriod: '전체 기간',
+    bookingStatus: '예약 상태',
+    vehicleType: '차량 유형',
+    paymentMethod: '결제 수단',
+    minDriverRating: '최소 운전자 평점',
+    minCustomerRating: '최소 고객 평점',
+    distanceRange: '거리 범위 (km)',
+    priceRange: '가격 범위 (USD)',
+    min: '최소',
+    max: '최대',
+    pickupLocationTop10: '픽업 위치 (상위 10개)',
+    dropLocationTop10: '도착 위치 (상위 10개)',
+
+    // Data Table
+    bookingData: '예약 데이터',
+    records: '개 기록',
+    perPage: '개씩 보기',
+    exportCSV: 'CSV 내보내기',
+    exportJSON: 'JSON 내보내기',
+    showing: '표시 중',
+    to: '~',
+    of: '/',
+    entries: '개 항목',
+    date: '날짜',
+    time: '시간',
+    bookingId: '예약 ID',
+    status: '상태',
+    vehicle: '차량',
+    pickup: '픽업',
+    drop: '도착',
+    priceUSD: '가격 (USD)',
+    distanceKm: '거리 (km)',
+    driverRating: '운전자 평점',
+    customerRating: '고객 평점',
+    payment: '결제',
+
+    // Footer
+    showingOf: '개 중',
+    bookingsDisplayed: '개의 예약 표시',
+    copyright: 'Statify 예약 분석 대시보드 © 2025',
+
+    // Language Toggle
+    language: '한국어'
+  },
+  en: {
+    // Header
+    dashboardTitle: 'Booking Analytics Dashboard',
+    teamName: 'Team: Statify',
+    recordsAnalysis: ' booking records analyzed',
+    refresh: 'Refresh',
+
+    // Tabs
+    overview: 'Overview',
+    charts: 'Charts',
+    dataTable: 'Data Table',
+
+    // Loading & Error
+    loadingData: 'Loading booking data...',
+    loadingSubtitle: 'Large datasets may take some time',
+    loadError: 'Data Loading Error',
+    retry: 'Retry',
+
+    // No Data
+    noData: 'No Data',
+    noDataMessage: 'No matching data found. Try adjusting or resetting filters.',
+    resetFilters: 'Reset Filters',
+
+    // Stats Cards
+    totalBookings: 'Total Bookings',
+    completed: ' completed',
+    completionRate: 'Completion Rate',
+    successfulRides: 'Successfully completed rides',
+    cancellationRate: 'Cancellation Rate',
+    totalCancelled: ' total cancelled',
+    totalRevenue: 'Total Revenue',
+    avgPerRide: 'per ride',
+    avgDriverRating: 'Avg Driver Rating',
+    avgCustomerRating: 'Avg Customer Rating',
+    outOf5: 'out of 5.0',
+    totalDistance: 'Total Distance',
+    perRide: 'per ride',
+    customerCancelled: 'Customer Cancelled',
+    customerCancelledCount: 'Cancelled by customers',
+    driverCancelled: 'Driver Cancelled',
+    driverCancelledCount: 'Cancelled by drivers',
+    exportStats: 'Export Stats',
+
+    // Charts
+    bookingStatusDist: 'Booking Status Distribution',
+    bookingsByVehicle: 'Bookings by Vehicle Type',
+    paymentMethodDist: 'Payment Method Distribution',
+    bookingsByHour: 'Bookings by Hour',
+    topDropLocations: 'Top 10 Drop Locations',
+    topPickupLocations: 'Top 10 Pickup Locations',
+    revenueByVehicle: 'Revenue by Vehicle Type (USD)',
+    bookingsTrend: 'Booking Trend (Last 30 Days)',
+
+    // Filter Panel
+    filters: 'Filters',
+    resetAll: 'Reset All',
+    search: 'Search',
+    searchPlaceholder: 'Search by ID, location, vehicle...',
+    dateRange: 'Date Range',
+    last7Days: 'Last 7 Days',
+    last30Days: 'Last 30 Days',
+    allPeriod: 'All Time',
+    bookingStatus: 'Booking Status',
+    vehicleType: 'Vehicle Type',
+    paymentMethod: 'Payment Method',
+    minDriverRating: 'Min Driver Rating',
+    minCustomerRating: 'Min Customer Rating',
+    distanceRange: 'Distance Range (km)',
+    priceRange: 'Price Range (USD)',
+    min: 'Min',
+    max: 'Max',
+    pickupLocationTop10: 'Pickup Location (Top 10)',
+    dropLocationTop10: 'Drop Location (Top 10)',
+
+    // Data Table
+    bookingData: 'Booking Data',
+    records: ' records',
+    perPage: ' per page',
+    exportCSV: 'Export CSV',
+    exportJSON: 'Export JSON',
+    showing: 'Showing',
+    to: 'to',
+    of: 'of',
+    entries: 'entries',
+    date: 'Date',
+    time: 'Time',
+    bookingId: 'Booking ID',
+    status: 'Status',
+    vehicle: 'Vehicle',
+    pickup: 'Pickup',
+    drop: 'Drop',
+    priceUSD: 'Price (USD)',
+    distanceKm: 'Distance (km)',
+    driverRating: 'Driver Rating',
+    customerRating: 'Customer Rating',
+    payment: 'Payment',
+
+    // Footer
+    showingOf: 'of',
+    bookingsDisplayed: ' bookings displayed',
+    copyright: 'Statify Booking Analytics Dashboard © 2025',
+
+    // Language Toggle
+    language: 'English'
+  }
+};
+
+export const getTranslation = (lang, key) => {
+  return translations[lang]?.[key] || key;
+};


### PR DESCRIPTION
## 🔥 관련 이슈
  Close #33 

##📃 변경 사항

  기존 한글로만 되어 있던 대시보드에 한/영 언어 전환 토글 기능을
  추가했습니다.

  - 번역 데이터 파일 추가 (translations.js)
  - App.jsx에 언어 상태 관리 및 토글 버튼 추가
  - Charts, FilterPanel, DataTable 컴포넌트에 다국어 지원 적용
  - 토글 버튼 CSS 스타일 추가

<img width="1003" height="578" alt="스크린샷 2025-12-04 오후 8 19 06" src="https://github.com/user-attachments/assets/af4f5f8e-b7a7-4660-bb99-5996001bc500" />
<img width="1000" height="618" alt="스크린샷 2025-12-04 오후 8 19 10" src="https://github.com/user-attachments/assets/f74ff467-e77c-4b8b-a7e7-e2003c1f1b8e" />

## 🛠 구현 상세

  1. 번역 데이터 구조 설계

  src/utils/translations.js 파일에 한국어/영어 번역을 객체로 관리합니다.

  export const translations = {
    ko: { dashboardTitle: '예약 분석 대시보드', ... },
    en: { dashboardTitle: 'Booking Analytics Dashboard', ... }
  };

  2. React 상태 기반 언어 전환

  App.jsx에서 useState를 사용하여 현재 언어 상태를 관리합니다.

  const [lang, setLang] = useState('ko');
  const t = translations[lang];

  토글 버튼 클릭 시 lang 상태가 전환되며, React의 리렌더링으로 전체 UI가
  해당 언어로 변경됩니다.

  3. 컴포넌트별 번역 적용

  각 컴포넌트에 t prop을 전달하여 하드코딩된 텍스트를 동적으로 변경합니다.

  - Charts.jsx: 차트 제목 (예약 상태 분포, 차량 유형별 예약 등)
  - FilterPanel.jsx: 필터 레이블 및 버튼 텍스트
  - DataTable.jsx: 테이블 헤더, 페이지네이션 텍스트


##  🔍 기능 테스트
  - 토글 버튼 클릭 시 모든 UI 텍스트가 한/영으로 즉시 전환되는지
  확인했습니다.
  - 언어 전환 후에도 필터, 차트, 데이터 테이블 기능이 정상 동작하는지
  확인했습니다.
  - npm run build 빌드 성공 여부를 확인했습니다.


##  📝 참고 사항

  - 번역이 필요한 텍스트는 src/utils/translations.js에 추가하면 됩니다.
  - 향후 다른 언어 추가 시 translations 객체에 해당 언어 키를 추가하면 확장
  가능합니다.
